### PR TITLE
[WIP] Partial results display prototype, refactor warning / error handling

### DIFF
--- a/ui/components/src/ErrorAlert.tsx
+++ b/ui/components/src/ErrorAlert.tsx
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useMemo } from 'react';
+import { UserFriendlyError } from '@perses-dev/core';
 import { Alert } from '@mui/material';
 
 export interface ErrorAlertProps {
@@ -22,5 +24,29 @@ export interface ErrorAlertProps {
  */
 export function ErrorAlert(props: ErrorAlertProps) {
   const { error } = props;
-  return <Alert severity="error">{error.message}</Alert>;
+
+  const { errors: errorMessages } = useMemo(
+    () => getUserFriendlyErrors(error, 'There was an error loading this page. Please try again.'),
+    [error]
+  );
+
+  return <Alert severity="error">{errorMessages}</Alert>;
+}
+
+interface UserFriendlyErrors {
+  errors: string[];
+}
+
+/**
+ * Given a server error, determines the user-friendly message(s) to show.
+ */
+export function getUserFriendlyErrors(error: unknown, defaultMessage: string): UserFriendlyErrors {
+  // UserFriendlyError messages can be shown as-is
+  if (error instanceof UserFriendlyError) {
+    const errorEvent = error as UserFriendlyError;
+    return { errors: [errorEvent.message] };
+  }
+
+  // Otherwise, use the fallback/default message
+  return { errors: [defaultMessage] };
 }

--- a/ui/components/src/ErrorAlert.tsx
+++ b/ui/components/src/ErrorAlert.tsx
@@ -26,7 +26,7 @@ export function ErrorAlert(props: ErrorAlertProps) {
   const { error } = props;
 
   const { errors: errorMessages } = useMemo(
-    () => getUserFriendlyErrors(error, 'There was an error loading this page. Please try again.'),
+    () => getUserFriendlyErrors(error, 'Failed to load response data.'),
     [error]
   );
 

--- a/ui/core/src/model/actions.ts
+++ b/ui/core/src/model/actions.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 export interface Action {
-  kind: 'Error' | 'Info' | 'Success' | 'Warning';
+  type: 'error' | 'info' | 'warning';
   message: string;
+  display?: 'tag'; // TODO: define other action types and alternate display options
 }

--- a/ui/core/src/model/actions.ts
+++ b/ui/core/src/model/actions.ts
@@ -11,17 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './actions';
-export * from './dashboard';
-export * from './datasource';
-export * from './display';
-export * from './definitions';
-export * from './display';
-export * from './http';
-export * from './layout';
-export * from './panels';
-export * from './resource';
-export * from './thresholds';
-export * from './time';
-export * from './time-series-queries';
-export * from './variables';
+export interface Action {
+  kind: 'Error' | 'Info' | 'Success' | 'Warning';
+  message: string;
+}

--- a/ui/core/src/utils/fetch.ts
+++ b/ui/core/src/utils/fetch.ts
@@ -17,6 +17,13 @@
 export async function fetch(...args: Parameters<typeof global.fetch>) {
   const response = await global.fetch(...args);
   if (response.ok === false) {
+    const json = await response.json();
+    if (json.error) {
+      throw new UserFriendlyError(json.error);
+    }
+    if (json.message) {
+      throw new UserFriendlyError(json.message);
+    }
     throw new FetchError(response);
   }
   return response;
@@ -40,5 +47,15 @@ export class FetchError extends Error {
   constructor(response: Readonly<Response>) {
     super(`${response.status} ${response.statusText}`);
     Object.setPrototypeOf(this, FetchError.prototype);
+  }
+}
+
+/**
+ * General error type for an error that has a message that is OK to show to the end user.
+ */
+export class UserFriendlyError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, UserFriendlyError.prototype);
   }
 }

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   DashboardResource,
   DashboardSpec,
@@ -19,6 +19,7 @@ import {
   DatasourceSelector,
   DatasourceSpec,
   GlobalDatasource,
+  RequestHeaders,
   useEvent,
 } from '@perses-dev/core';
 import {
@@ -56,6 +57,8 @@ export interface DatasourceApi {
 export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
   const { dashboardResource, datasourceApi, children } = props;
   const { project } = dashboardResource.metadata;
+
+  const [headerOverrides, setHeaderOverrides] = useState<RequestHeaders>();
 
   const { getPlugin, listPluginMetadata } = usePluginRegistry();
 
@@ -96,10 +99,22 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
     async function getClient<Client>(selector: DatasourceSelector): Promise<Client> {
       const { kind } = selector;
       const [{ spec, proxyUrl }, plugin] = await Promise.all([findDatasource(selector), getPlugin('Datasource', kind)]);
-      return plugin.createClient(spec.plugin.spec, { proxyUrl }) as Client;
+
+      // default HTTP request headers can be overriden through plugin system
+      const datasourceSpec = { ...spec.plugin.spec };
+      if (headerOverrides !== undefined) {
+        datasourceSpec.headers = headerOverrides;
+      }
+
+      return plugin.createClient(datasourceSpec, { proxyUrl }) as Client;
     },
-    [findDatasource, getPlugin]
+    [findDatasource, getPlugin, headerOverrides]
   );
+
+  // Override the default HTTP Headers set in datasource plugin spec
+  const setActiveDatasourceHeaders = useCallback((value: RequestHeaders) => {
+    setHeaderOverrides(value);
+  }, []);
 
   const listDatasourceMetadata = useEvent(async (datasourcePluginKind: string): Promise<DatasourceMetadata[]> => {
     const [pluginMetadata, datasources, globalDatasources] = await Promise.all([
@@ -146,8 +161,10 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
       getDatasource,
       getDatasourceClient,
       listDatasourceMetadata,
+      activeDatasourceHeaders: headerOverrides,
+      setActiveDatasourceHeaders,
     }),
-    [getDatasource, getDatasourceClient, listDatasourceMetadata]
+    [getDatasource, getDatasourceClient, listDatasourceMetadata, headerOverrides, setActiveDatasourceHeaders]
   );
 
   return <DatasourceStoreContext.Provider value={ctxValue}>{children}</DatasourceStoreContext.Provider>;

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -13,6 +13,7 @@
 
 import { useState } from 'react';
 import { Box } from '@mui/material';
+import { QueryInspector } from '@perses-dev/plugin-system';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
 import {
@@ -98,6 +99,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
       />
       <Box sx={{ padding: (theme) => theme.spacing(2) }}>
         <ErrorBoundary FallbackComponent={ErrorAlert}>
+          <QueryInspector showTotalQueries={true} />
           <Dashboard />
         </ErrorBoundary>
         <PanelDrawer />

--- a/ui/plugin-system/src/components/PluginSpecEditor.test.tsx
+++ b/ui/plugin-system/src/components/PluginSpecEditor.test.tsx
@@ -58,6 +58,7 @@ describe('PluginSpecEditor', () => {
   it('shows an error if plugin fails to load', async () => {
     renderComponent({ pluginType: 'Variable', pluginKind: 'DoesNotExist', value: {}, onChange: jest.fn() });
     const errorAlert = await screen.findByRole('alert');
+    // TODO: fix test error
     expect(errorAlert).toHaveTextContent(/doesnotexist/i);
   });
 });

--- a/ui/plugin-system/src/components/QueryInspector.tsx
+++ b/ui/plugin-system/src/components/QueryInspector.tsx
@@ -1,0 +1,164 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Stack,
+} from '@mui/material';
+import { useQueryClient, Query, QueryCache, QueryKey } from '@tanstack/react-query';
+import { TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
+import { TIME_SERIES_QUERY_KEY, useTimeRange } from '../runtime';
+import { TimeSeriesData } from '../model';
+
+export interface WarningEvent {
+  query: string;
+  summary: string;
+}
+
+interface QueryInspectorProps {
+  showTotalQueries?: boolean;
+}
+
+export function QueryInspector(props: QueryInspectorProps) {
+  const { showTotalQueries } = props;
+  const queryClient = useQueryClient();
+  const queries = queryClient.getQueryCache().findAll();
+  const activeQueries = queries.filter((query) => query.state.status === 'loading');
+  const completedQueries = queries.filter((query) => query.state.status === 'success');
+
+  const { absoluteTimeRange } = useTimeRange();
+
+  const querySummary = useCurrentTimeSeriesQueries();
+
+  const warningEvents: WarningEvent[] = [];
+  querySummary.forEach((query) => {
+    const queryData = query.state.data;
+    if (queryData && queryData.warnings) {
+      const queryKey = query.queryKey as [TimeSeriesQueryDefinition<UnknownSpec>];
+      warningEvents.push({
+        query: String(queryKey[0].spec.plugin.spec.query),
+        summary: getResponseHeadersSummary(queryData.warnings),
+      });
+    }
+  });
+
+  return (
+    <Stack spacing={2} mb={2}>
+      <Box>
+        <Typography variant="h2" mb={1}>
+          Query Summary
+        </Typography>
+        <TableContainer component={Paper}>
+          <Table
+            sx={{
+              maxWidth: 800,
+            }}
+            size="small"
+            aria-label="query inspector table"
+          >
+            <TableHead>
+              <TableRow>
+                <TableCell>Active Queries</TableCell>
+                <TableCell>Time Series Queries</TableCell>
+                {showTotalQueries && <TableCell>Total Queries</TableCell>}
+                <TableCell>Start Time</TableCell>
+                <TableCell>End Time</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>{activeQueries.length}</TableCell>
+                <TableCell>{querySummary.length}</TableCell>
+                {showTotalQueries && <TableCell>{completedQueries.length}</TableCell>}
+                <TableCell>{absoluteTimeRange.start.toString()}</TableCell>
+                <TableCell>{absoluteTimeRange.end.toString()}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+
+      {warningEvents.length > 0 && (
+        <Box>
+          <Typography variant="h3" mb={1}>
+            Warnings
+          </Typography>
+          <TableContainer component={Paper} sx={{ mb: 2 }}>
+            <Table
+              sx={{
+                maxWidth: 800,
+              }}
+              size="small"
+              aria-label="query warnings table"
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell>Query</TableCell>
+                  <TableCell>Warning</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {warningEvents.map((details, idx) => {
+                  return (
+                    <TableRow key={idx}>
+                      <TableCell>{details.query}</TableCell>
+                      <TableCell>{details.summary}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+export function getTimeSeriesQuerySummary(cache: QueryCache) {
+  const queries = cache
+    .findAll({ type: 'active' })
+    .filter((query) => {
+      const firstPart = query.queryKey?.[0] as UnknownSpec;
+      if (firstPart?.kind) {
+        return (firstPart?.kind as string).startsWith(TIME_SERIES_QUERY_KEY);
+      }
+      return false;
+    })
+    .filter((query) => query.isActive)
+    .map((query) => {
+      return query as Query<TimeSeriesData, unknown, TimeSeriesData, QueryKey>;
+    });
+  return queries;
+}
+
+/**
+ * Get response headers for query inspection summary
+ */
+export function getResponseHeadersSummary(response: string | string[]): string {
+  if (!response) {
+    return '';
+  }
+  if (typeof response === 'string') {
+    return response;
+  }
+  if (response.length) {
+    return response[0] ?? '';
+  }
+  return '';
+}
+
+/**
+ * Show info about running time series queries for results summary
+ */
+export function useCurrentTimeSeriesQueries() {
+  const queryClient = useQueryClient();
+  const queryCache = queryClient.getQueryCache();
+  const timeSeriesQueries = getTimeSeriesQuerySummary(queryCache);
+  return timeSeriesQueries;
+}

--- a/ui/plugin-system/src/components/QueryInspector.tsx
+++ b/ui/plugin-system/src/components/QueryInspector.tsx
@@ -10,10 +10,9 @@ import {
   Typography,
   Stack,
 } from '@mui/material';
-import { useQueryClient, Query, QueryCache, QueryKey } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
-import { TIME_SERIES_QUERY_KEY, useTimeRange } from '../runtime';
-import { TimeSeriesData } from '../model';
+import { useActiveTimeSeriesQueries, useTimeRange } from '../runtime';
 
 export interface WarningDisplay {
   query: string;
@@ -34,7 +33,7 @@ export function QueryInspector(props: QueryInspectorProps) {
 
   const { absoluteTimeRange } = useTimeRange();
 
-  const querySummary = useCurrentTimeSeriesQueries();
+  const querySummary = useActiveTimeSeriesQueries();
 
   const warnings: WarningDisplay[] = [];
   querySummary.forEach((query) => {
@@ -127,23 +126,6 @@ export function QueryInspector(props: QueryInspectorProps) {
   );
 }
 
-export function getTimeSeriesQuerySummary(cache: QueryCache) {
-  const queries = cache
-    .findAll({ type: 'active' })
-    .filter((query) => {
-      const firstPart = query.queryKey?.[0] as UnknownSpec;
-      if (firstPart?.kind) {
-        return (firstPart?.kind as string).startsWith(TIME_SERIES_QUERY_KEY);
-      }
-      return false;
-    })
-    .filter((query) => query.isActive)
-    .map((query) => {
-      return query as Query<TimeSeriesData, unknown, TimeSeriesData, QueryKey>;
-    });
-  return queries;
-}
-
 /**
  * Get response headers for query inspection summary
  */
@@ -161,14 +143,4 @@ export function getResponseHeadersSummary(header: string) {
     return header;
   }
   return '';
-}
-
-/**
- * Show info about running time series queries for results summary
- */
-export function useCurrentTimeSeriesQueries() {
-  const queryClient = useQueryClient();
-  const queryCache = queryClient.getQueryCache();
-  const timeSeriesQueries = getTimeSeriesQuerySummary(queryCache);
-  return timeSeriesQueries;
 }

--- a/ui/plugin-system/src/components/QueryInspector.tsx
+++ b/ui/plugin-system/src/components/QueryInspector.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
-import { useActiveTimeSeriesQueries, useTimeRange } from '../runtime';
+import { useActiveDatasourceHeaders, useActiveTimeSeriesQueries, useTimeRange } from '../runtime';
 
 export interface WarningDisplay {
   query: string;
@@ -31,6 +31,8 @@ export function QueryInspector(props: QueryInspectorProps) {
   const queries = queryClient.getQueryCache().findAll();
   const activeQueries = queries.filter((query) => query.state.status === 'loading');
   const completedQueries = queries.filter((query) => query.state.status === 'success');
+
+  const { setActiveDatasourceHeaders } = useActiveDatasourceHeaders();
 
   const { absoluteTimeRange } = useTimeRange();
 
@@ -124,9 +126,8 @@ export function QueryInspector(props: QueryInspectorProps) {
           <Button
             variant="outlined"
             onClick={() => {
-              console.log(
-                'TODO: disable query limit headers, will call setDatasourceHeaders from @perses-dev/plugin-system'
-              );
+              // clear query limit HTTP headers
+              setActiveDatasourceHeaders({});
             }}
           >
             Disable Query Truncation

--- a/ui/plugin-system/src/components/QueryInspector.tsx
+++ b/ui/plugin-system/src/components/QueryInspector.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Paper,
   Table,
   TableBody,
@@ -120,6 +121,16 @@ export function QueryInspector(props: QueryInspectorProps) {
               </TableBody>
             </Table>
           </TableContainer>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              console.log(
+                'TODO: disable query limit headers, will call setDatasourceHeaders from @perses-dev/plugin-system'
+              );
+            }}
+          >
+            Disable Query Truncation
+          </Button>
         </Box>
       )}
     </Stack>

--- a/ui/plugin-system/src/components/index.ts
+++ b/ui/plugin-system/src/components/index.ts
@@ -18,4 +18,5 @@ export * from './PluginEditor';
 export * from './PluginKindSelect';
 export * from './PluginRegistry';
 export * from './PluginSpecEditor';
+export * from './QueryInspector';
 export * from './TimeSeriesQueryEditor';

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -49,7 +49,6 @@ export interface TimeSeriesData {
   timeRange?: AbsoluteTimeRange;
   stepMs?: number;
   series: TimeSeries[];
-  warnings?: string[];
   actions?: Action[];
 }
 

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -49,6 +49,7 @@ export interface TimeSeriesData {
   timeRange?: AbsoluteTimeRange;
   stepMs?: number;
   series: TimeSeries[];
+  warnings?: string[];
 }
 
 export interface TimeSeries {

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AbsoluteTimeRange, TimeSeriesValueTuple, UnknownSpec } from '@perses-dev/core';
+import { AbsoluteTimeRange, Action, TimeSeriesValueTuple, UnknownSpec } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
 import { Plugin } from './plugin-base';
 
@@ -50,6 +50,7 @@ export interface TimeSeriesData {
   stepMs?: number;
   series: TimeSeries[];
   warnings?: string[];
+  actions?: Action[];
 }
 
 export interface TimeSeries {

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelector, DatasourceSpec } from '@perses-dev/core';
+import { DatasourceSelector, DatasourceSpec, RequestHeaders } from '@perses-dev/core';
 import { useQuery } from '@tanstack/react-query';
 import { createContext, useContext } from 'react';
 
@@ -28,6 +28,15 @@ export interface DatasourceStore {
    * Gets a list of datasource metadata for a plugin kind.
    */
   listDatasourceMetadata(datasourcePluginKind: string): Promise<DatasourceMetadata[]>;
+
+  /**
+   * Global datasource HTTP headers
+   */
+  activeDatasourceHeaders?: RequestHeaders;
+  /**
+   * Override custom HTTP Headers
+   */
+  setActiveDatasourceHeaders: (value: RequestHeaders) => void;
 }
 
 export interface DatasourceMetadata {
@@ -60,4 +69,13 @@ export function useListDatasources(datasourcePluginKind: string) {
 export function useDatasourceClient<Client>(selector: DatasourceSelector) {
   const store = useDatasourceStore();
   return useQuery<Client>(['getDatasourceClient', selector], () => store.getDatasourceClient<Client>(selector));
+}
+
+/**
+ * Adds ability to get and set custom headers defined in datasource spec
+ */
+export function useActiveDatasourceHeaders() {
+  // TODO: pass datasourceName as optional param to only override specific datasource
+  const { activeDatasourceHeaders, setActiveDatasourceHeaders } = useDatasourceStore();
+  return { activeDatasourceHeaders, setActiveDatasourceHeaders };
 }

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -25,6 +25,8 @@ export interface UseTimeSeriesQueryOptions {
   suggestedStepMs?: number;
 }
 
+export const TIME_SERIES_QUERY_KEY = 'TimeSeriesQuery';
+
 /**
  * Returns a serialized string of the current state of variable values.
  */
@@ -65,6 +67,7 @@ function getQueryOptions({
   if (variableDependencies) {
     waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
   }
+
   const queryEnabled = plugin !== undefined && !waitToLoad;
 
   return {
@@ -77,7 +80,7 @@ function getQueryOptions({
  * Runs a time series query using a plugin and returns the results.
  */
 export const useTimeSeriesQuery = (definition: TimeSeriesQueryDefinition, options?: UseTimeSeriesQueryOptions) => {
-  const { data: plugin } = usePlugin('TimeSeriesQuery', definition.spec.plugin.kind);
+  const { data: plugin } = usePlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
 
   const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
@@ -104,7 +107,7 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
   const context = useTimeSeriesQueryContext();
 
   const pluginLoaderResponse = usePlugins(
-    'TimeSeriesQuery',
+    TIME_SERIES_QUERY_KEY,
     definitions.map((d) => ({ kind: d.spec.plugin.kind }))
   );
 
@@ -118,7 +121,7 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
         queryFn: async () => {
           // Keep options out of query key so we don't re-run queries because suggested step changes
           const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
-          const plugin = await getPlugin('TimeSeriesQuery', definition.spec.plugin.kind);
+          const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
           const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
           return data;
         },
@@ -127,6 +130,9 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
   });
 }
 
+/**
+ * Build the context object from data available at runtime
+ */
 function useTimeSeriesQueryContext(): TimeSeriesQueryContext {
   // Build the context object from data available at runtime
   const { absoluteTimeRange, refreshKey } = useTimeRange();

--- a/ui/prometheus-plugin/src/model/api-types.ts
+++ b/ui/prometheus-plugin/src/model/api-types.ts
@@ -74,6 +74,7 @@ export interface RangeQueryRequestParameters {
   end: UnixTimestampSeconds;
   step: DurationSeconds;
   timeout?: DurationString;
+  warnings_header?: string;
 }
 
 export type RangeQueryResponse = ApiResponse<MatrixData>;

--- a/ui/prometheus-plugin/src/model/prometheus-client.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-client.ts
@@ -142,6 +142,6 @@ export async function fetchResults<T>(warnings_header?: string, ...args: Paramet
   const json: T = await response.json();
   const entries = [...response.headers.entries()];
   const entry = entries.find((entry) => entry[0] === warnings_header);
-  const warnings = entry?.[1];
-  return { ...json, warnings };
+  const warning = entry?.[1];
+  return { ...json, warnings: [warning] };
 }

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -18,13 +18,14 @@ import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } f
 export interface PrometheusDatasourceSpec {
   direct_url?: string;
   headers?: RequestHeaders;
+  warnings_header?: string;
 }
 
 /**
  * Creates a PrometheusClient for a specific datasource spec.
  */
 const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>['createClient'] = (spec, options) => {
-  const { direct_url, headers } = spec;
+  const { direct_url, headers, warnings_header } = spec;
   const { proxyUrl } = options;
 
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
@@ -38,10 +39,10 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
     options: {
       datasourceUrl,
     },
-    instantQuery: (params) => instantQuery(params, { datasourceUrl, headers }),
-    rangeQuery: (params) => rangeQuery(params, { datasourceUrl, headers }),
-    labelNames: (params) => labelNames(params, { datasourceUrl, headers }),
-    labelValues: (params) => labelValues(params, { datasourceUrl, headers }),
+    instantQuery: (params) => instantQuery(params, { datasourceUrl, headers, warnings_header }),
+    rangeQuery: (params) => rangeQuery(params, { datasourceUrl, headers, warnings_header }),
+    labelNames: (params) => labelNames(params, { datasourceUrl, headers, warnings_header }),
+    labelValues: (params) => labelValues(params, { datasourceUrl, headers, warnings_header }),
   };
 };
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -61,8 +61,9 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
     step,
   });
 
-  // TODO: What about error responses from Prom that have a response body?
   const result = response.data?.result ?? [];
+
+  const warnings = response.status === 'success' ? response.warnings : [];
 
   // Transform response
   const chartData: TimeSeriesData = {
@@ -89,6 +90,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
         formattedName,
       };
     }),
+    warnings,
   };
 
   return chartData;

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -64,15 +64,8 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
 
   const result = response.data?.result ?? [];
 
+  // Custom display for response header warnings, configurable error responses display coming next
   const actions: Action[] = [];
-  const errorMessage = response.status === 'error' ? response.error : '';
-  if (errorMessage !== '') {
-    actions.push({
-      kind: 'Error',
-      message: errorMessage,
-    });
-  }
-
   const warnings = response.status === 'success' ? response.warnings : [];
   const warningMessage = warnings && warnings[0] ? warnings[0] : '';
   if (warningMessage !== '') {
@@ -97,7 +90,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
         name = query;
       }
 
-      // query editor allows you to define an optional series_name_format
+      // Query editor allows you to define an optional series_name_format
       // property to customize legend and tooltip display
       const formattedName = spec.series_name_format ? formatSeriesName(spec.series_name_format, metric) : name;
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Action } from '@perses-dev/core';
 import { TimeSeriesData, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
 import { fromUnixTime } from 'date-fns';
 import {
@@ -63,7 +64,23 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
 
   const result = response.data?.result ?? [];
 
+  const actions: Action[] = [];
+  const errorMessage = response.status === 'error' ? response.error : '';
+  if (errorMessage !== '') {
+    actions.push({
+      kind: 'Error',
+      message: errorMessage,
+    });
+  }
+
   const warnings = response.status === 'success' ? response.warnings : [];
+  const warningMessage = warnings && warnings[0] ? warnings[0] : '';
+  if (warningMessage !== '') {
+    actions.push({
+      kind: 'Warning',
+      message: warningMessage,
+    });
+  }
 
   // Transform response
   const chartData: TimeSeriesData = {
@@ -91,6 +108,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
       };
     }),
     warnings,
+    actions,
   };
 
   return chartData;

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -70,7 +70,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   const warningMessage = warnings && warnings[0] ? warnings[0] : '';
   if (warningMessage !== '') {
     actions.push({
-      kind: 'Warning',
+      type: 'warning',
       message: warningMessage,
     });
   }
@@ -100,7 +100,6 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
         formattedName,
       };
     }),
-    warnings,
     actions,
   };
 


### PR DESCRIPTION
Query truncation prototype that includes potential datasource spec changes, fetch updates, and an additional `actions` property on TimeSeriesQuery results.

Here is the datasource I'm using to test these changes:
```json
{
  "kind": "GlobalDatasource",
  "metadata": { "name": "PrometheusM3Proxy" },
  "spec": {
    "default": false,
    "plugin": {
      "kind": "PrometheusDatasource",
      "spec": {
        "headers": {
          "m3-limit-max-returned-datapoints": "50",
          "m3-limit-max-returned-series": "1"
        },
        "warnings_header": "m3-returned-data-limited",
        "proxy": {
          "kind": "HTTPProxy",
          "spec": {
            "url": "http://localhost:8000/data/metrics"
          }
        }
      }
    }
  }
}
```